### PR TITLE
Fix typo in  .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,8 +5,8 @@
 ^README\.Rmd$
 ^\.github$
 ^\.pre-commit-config.yaml$
-^\.pixi\.toml$
-^\.pixi\.lock$
+^pixi\.toml$
+^pixi\.lock$
 ^CODE_OF_CONDUCT\.md$
 ^CONTRIBUTING\.md$
 ^newsfragments$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,12 @@ Package: fastMatMR
 Title: "fastMatMR: High-Performance Matrix Market File Operations in R"
 Version: 1.1.0
 Authors@R:
-    person("Rohit", "Goswami", , "rgoswami@ieee.org", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0002-2393-8056"))
+    c(
+    person("Rohit", "Goswami", email = "rgoswami@ieee.org", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-2393-8056")),
+    person("Ildiko", "Czeller", email = "czeildi@users.noreply.github.com", role = c("rev"),
+           comment = c(ORCID = "0000-0002-9418-4589"))
+           )
 Description: "fastMatMR is an R package offering high-performance read and write operations for Matrix Market files. It acts as a thin wrapper around the 'fast_matrix_market' C++ library, offering speed and extended support for Matrix Market formats. Unlike other R packages, fastMatMR supports not just sparse matrices but also dense vectors and matrices. This makes it a versatile choice for dealing with .mtx files in R."
 License: MIT + file LICENSE
 SystemRequirements: C++17


### PR DESCRIPTION
Follows up https://github.com/HaoZeke/fastMatMR/issues/43 

I think there is still a small typo in .Rbuildignore, this PR fixes it. There are 2 small notes in https://github.com/HaoZeke/fastMatMR/actions/runs/6621182102/job/17984804437 and also locally.

(This is really not important, I just wanted to follow up as you already worked on fixing it)